### PR TITLE
19 Add IE polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "css-loader": "^0.28.0",
+    "es6-object-assign": "^1.1.0",
+    "es6-promise": "^4.1.1",
     "express": "^4.15.2",
     "extract-text-webpack-plugin": "^2.1.0",
     "import-glob-loader": "^1.1.0",

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,8 +1,14 @@
 import { applyMiddleware, compose, createStore } from 'redux';
+import Es6ObjectAssign from 'es6-object-assign';
+import Es6Promise from 'es6-promise';
 import middlewares from 'redux/middlewares';
 import reducers from 'redux/reducers';
 
 const appliedMiddleware = applyMiddleware(...middlewares);
 const initialState = {};
+
+// ie polyfills
+Es6ObjectAssign.polyfill();
+Es6Promise.polyfill();
 
 export default createStore(reducers, initialState, compose(appliedMiddleware));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,10 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
+es6-object-assign@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+
 es6-promise@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"


### PR DESCRIPTION
closes #19 

**This PR:**

* Adds the [es6-object-assign](https://github.com/rubennorte/es6-object-assign) package
* Adds the [es6-promise](https://github.com/stefanpenner/es6-promise)
* Modifies the global objects for `Promise` and `Object` to polyfill the global environment

**Why?**

* This change is made to support older browser versions (IE).