### PR TITLE
Fix bug retrieving bearer token key in local storage

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -13,5 +13,5 @@ class Api extends Schlepp {
 
 export default new Api({
   host: constants.API_HOST,
-  bearerTokenKeyInLocalStorage: `${constants.APP_NAME}::auth_token`,
+  bearerTokenKeyInLocalStorage: `${constants.APP_NAME}:auth_token`,
 });


### PR DESCRIPTION
This commit:

* Modifies the API client's bearer token key in local storage

Why?

* The storage function uses one colon and the API client's default
bearer token key in local storage was using two so the bearer token was
being sent as undefined